### PR TITLE
Strip \n or \t in bval 

### DIFF
--- a/bin/qc-dti
+++ b/bin/qc-dti
@@ -48,7 +48,7 @@ def float_to_int(filename):
     '''
 
     with open(filename,'r') as f: 
-        raw_file = f.read().split(' ')
+        raw_file = f.read().strip().split(' ')
 
     int_list = [str(int(float(b))) for b in raw_file]
     write_str = ' '.join(int_list)  


### PR DESCRIPTION
When trying to run qc-dti on VRMD study, got error:
```
qcmon/bin/qc-dti", line 53, in float_to_int
    int_list = [str(int(float(b))) for b in raw_file]
ValueError: could not convert string to float: 
```