### PR TITLE
Turn off bvec checking to avoid false errors

### DIFF
--- a/bin/qc-headers
+++ b/bin/qc-headers
@@ -341,7 +341,7 @@ def main():
     mismatches = compare_headers(standardHeader, dicomHeader, tolerances=tolerances, ignore=ignore)
 
     if dti:
-        mismatches.extend(check_bfile(dicom, standard, 'bvec')) 
+        #mismatches.extend(check_bfile(dicom, standard, 'bvec')) 
         mismatches.extend(check_bfile(dicom, standard, 'bval')) 
 
     print('{} mismatches for {}'.format(len(mismatches), dicom))


### PR DESCRIPTION
We should eventually make the system rotate the bvecs so we can actually check them