### PR TITLE
[FIX] Update references to numpy functions/attributes

### DIFF
--- a/bin/qc-adni
+++ b/bin/qc-adni
@@ -186,7 +186,7 @@ def gauss_blur(vol,sig):
         sig                 Gaussian sigma [default=1]
     '''
 
-    blur_vol = np.zeros_like(vol,dtype=np.float)
+    blur_vol = np.zeros_like(vol,dtype=np.float64)
 
     for i in np.arange(0,vol.shape[2]):
         blur_vol[:,:,i] = gauss_kernel(vol[:,:,i],sigma=sig,preserve_range=True)
@@ -259,7 +259,7 @@ def process_phantom(nifti, output_prefix, valid_radii, tmpdir, mp4=None):
 
     #Load in, axialize to LPI, save in tempdir
     axial_path = axialize_LPI(nifti, tmpdir)
-    axial_vol = nib.load(axial_path).get_data()
+    axial_vol = nib.load(axial_path).get_fdata()
 
     #Generate mask, clean noise, connect edges
     logger.info('Generating mask...')
@@ -268,7 +268,7 @@ def process_phantom(nifti, output_prefix, valid_radii, tmpdir, mp4=None):
 
     #Apply mask and connected components clustering
     logger.info('Applying mask...')
-    masked_vol = np.zeros_like(axial_vol,dtype=np.float)
+    masked_vol = np.zeros_like(axial_vol,dtype=np.float64)
     masked_vol[mask] = gauss_blur(axial_vol,sig=1)[mask]
     masked_vol = erosion(erosion(masked_vol > 0)) * 1
 

--- a/bin/qc-fmri
+++ b/bin/qc-fmri
@@ -101,7 +101,7 @@ def main(nifti, prefix, tmpdir):
 
     # calculate l2 norm, replacing zeros with smallest possible float
     norm = np.linalg.norm(func, ord=2, axis=1)
-    norm[np.where(norm == 0)[0]] = np.finfo(np.float).min
+    norm[np.where(norm == 0)[0]] = np.finfo(np.float64).min
 
     # corr: devide by norm, take mean, take dot of func & mean
     func = func / np.tile(norm, (dims[1], 1)).T

--- a/bin/qc-gif
+++ b/bin/qc-gif
@@ -107,10 +107,10 @@ def main():
     logging.info('Starting')
 
     # load in the data
-    image = nib.load(image).get_data()
+    image = nib.load(image).get_fdata()
 
     if label:
-        label = nib.load(label).get_data()
+        label = nib.load(label).get_fdata()
 
     # reorient the data to radiological (does this generalize?)
     image = np.transpose(image, (2,0,1))

--- a/bin/qc-img
+++ b/bin/qc-img
@@ -106,7 +106,7 @@ def main(image, name, filename, pic, cmaptype='grey', mode='3d', minval=None, ma
     image = str(image) # input checks
     opath = os.path.dirname(image) # grab the image folder
     output = str(image)
-    image = nib.load(image).get_data() # load in the daterbytes
+    image = nib.load(image).get_fdata() # load in the daterbytes
 
     if mode == '3d':
         if len(image.shape) > 3: # if image is 4D, only keep the first time-point

--- a/bin/qc-registration
+++ b/bin/qc-registration
@@ -59,9 +59,9 @@ def process_subject(path, expt, mode, subj, pdf):
         os.system('3dedge3 -input ' + anat + ' -prefix ' + edge)
 
     # load in data
-    edge = nib.load(edge).get_data()
-    anat = nib.load(anat).get_data()
-    reg = nib.load(reg).get_data()
+    edge = nib.load(edge).get_fdata()
+    anat = nib.load(anat).get_fdata()
+    reg = nib.load(reg).get_fdata()
 
     # reorient the data to radiological
     edge = reorient_to_radiological(edge)

--- a/bin/qc-spikecount
+++ b/bin/qc-spikecount
@@ -51,7 +51,7 @@ def main(nifti, output, bval=None):
 
     logging.info('Starting')
 
-    nifti = reorient_4d_image(nib.load(nifti).get_data())
+    nifti = reorient_4d_image(nib.load(nifti).get_fdata())
 
     if bval:
         bval = np.genfromtxt(bval)

--- a/qcmon/utilities.py
+++ b/qcmon/utilities.py
@@ -82,8 +82,8 @@ def loadnii(filename):
 
     # load everything in
     nifti = nib.load(filename)
-    affine = nifti.get_affine()
-    header = nifti.get_header()
+    affine = nifti._affine
+    header = nifti._header
     dims = list(nifti.shape)
 
     # if smaller than 3D
@@ -95,7 +95,7 @@ def loadnii(filename):
         raise Exception("Your data is at least a penteract (over 4 dimensions!)")
 
     # load in nifti and reshape to 2D
-    nifti = nifti.get_data()
+    nifti = nifti.get_fdata()
     if len(dims) == 3:
         dims.append(1)
     nifti = nifti.reshape(dims[0]*dims[1]*dims[2], dims[3])
@@ -262,8 +262,8 @@ def load_masked_data(func, mask):
     Accepts 'functional.nii.gz' and 'mask.nii.gz', and returns a voxels x
     timepoints matrix of the functional data in non-zero mask locations.
     """
-    func = nib.load(func).get_data()
-    mask = nib.load(mask).get_data()
+    func = nib.load(func).get_fdata()
+    mask = nib.load(mask).get_fdata()
 
     mask = mask.reshape(mask.shape[0]*mask.shape[1]*mask.shape[2])
     idx = np.where(mask > 0)[0]
@@ -290,15 +290,15 @@ def get_mask_dims(mask):
     """
 
     nifti = nib.load(mask)
-    affine = nifti.get_affine()
-    header = nifti.get_header()
+    affine = nifti._affine
+    header = nifti._header
     dims = list(nifti.shape)
 
     if len(dims) != 3:
         raise Exception("ERROR: Mask should be 3D")
 
     # get flattened indicies
-    nifti = nifti.get_data()
+    nifti = nifti.get_fdata()
     nifti = nifti.reshape(dims[0]*dims[1]*dims[2], 1)
     idx = np.where(nifti > 0)[0]
 


### PR DESCRIPTION
Newer versions of numpy and nibabel have deprecated a number of references used by qcmon. This updates them.